### PR TITLE
Fix issue with Chrome where Chrome may send an empty string request c…

### DIFF
--- a/src/main/java/com/richardcheng/httpIO/HttpRequest.java
+++ b/src/main/java/com/richardcheng/httpIO/HttpRequest.java
@@ -5,10 +5,10 @@ import java.io.IOException;
 import java.util.Base64;
 
 public class HttpRequest {
-    private String method;
-    private String uri;
-    private String version;
-    private String endpoint;
+    private String method = "";
+    private String uri = "";
+    private String version = "";
+    private String endpoint = "";
     private String data;
     private String log = "";
     private String auth = "";
@@ -16,9 +16,15 @@ public class HttpRequest {
     private String parameters = "";
     private String etag = "";
 
-    public void parseMessage(BufferedReader requestMessage) {
+    public boolean parseMessage(BufferedReader requestMessage) {
         try {
-            parseRequest(requestMessage.readLine());
+            String firstLine = requestMessage.readLine();
+
+            if (firstLine == null) {
+                return false;
+            }
+
+            parseRequest(firstLine);
 
             int size = 0;
 
@@ -48,6 +54,8 @@ public class HttpRequest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+
+        return true;
     }
 
     private void parseRequest(String request) {

--- a/src/main/java/com/richardcheng/javaserver/Server.java
+++ b/src/main/java/com/richardcheng/javaserver/Server.java
@@ -69,10 +69,13 @@ public class Server {
             serverSocket.bind(new InetSocketAddress(port));
             while (serverRunShouldLoop.shouldLoop()) {
                 Socket requestSocket = serverSocket.accept();
-                this.request(requestSocket);
-                this.response(requestSocket);
+                boolean requestResult = this.request(requestSocket);
+                if (requestResult) {
+                    this.response(requestSocket);
+                }
             }
         } catch (Exception e) {
+            e.printStackTrace();
             throw new RuntimeException("something went wrong");
         } finally {
             this.stop();
@@ -87,7 +90,7 @@ public class Server {
         }
     }
 
-    private void request(Socket requestSocket) {
+    private boolean request(Socket requestSocket) {
         BufferedReader requestMessage;
 
         try {
@@ -96,7 +99,7 @@ public class Server {
             throw new RuntimeException(e);
         }
 
-        request.parseMessage(requestMessage);
+        return request.parseMessage(requestMessage);
     }
 
     private void response(Socket requestSocket) {

--- a/src/test/java/com/richardcheng/httpIO/HttpRequestTest.java
+++ b/src/test/java/com/richardcheng/httpIO/HttpRequestTest.java
@@ -18,7 +18,20 @@ public class HttpRequestTest {
     public ExpectedException thrown = ExpectedException.none();
 
     @Test
-    public void parseMessage_ParseRequest_And_ForwardSlash_AsRootEndpoint() {
+    public void parseMessage_ReturnsFalse_whenInputStreamEmpty() {
+        BufferedReader request = new BufferedReader(
+                new InputStreamReader(
+                        new ByteArrayInputStream(
+                                "".getBytes(StandardCharsets.UTF_8))));
+        HttpRequest httpRequest = new HttpRequest();
+
+        boolean actualMethodReturn = httpRequest.parseMessage(request);
+
+        Assert.assertFalse(actualMethodReturn);
+    }
+
+    @Test
+    public void parseMessage_ParseRequest_And_ForwardSlash_AsRootEndpoint_andReturnsTrue() {
         BufferedReader request = new BufferedReader(
                 new InputStreamReader(
                         new ByteArrayInputStream(
@@ -29,12 +42,13 @@ public class HttpRequestTest {
         String expectedVersion = "HTTP/1.1";
         String expectedEndpoint = "root";
 
-        httpRequest.parseMessage(request);
+        boolean actualMethodReturn = httpRequest.parseMessage(request);
 
         Assert.assertEquals(expectedMethod, httpRequest.getMethod());
         Assert.assertEquals(expectedUri, httpRequest.getUri());
         Assert.assertEquals(expectedVersion, httpRequest.getVersion());
         Assert.assertEquals(expectedEndpoint, httpRequest.getEndpoint());
+        Assert.assertTrue(actualMethodReturn);
     }
 
     @Test
@@ -49,12 +63,13 @@ public class HttpRequestTest {
         String expectedVersion = "HTTP/1.1";
         String expectedEndpoint = "form";
 
-        httpRequest.parseMessage(request);
+        boolean actualMethodReturn = httpRequest.parseMessage(request);
 
         Assert.assertEquals(expectedMethod, httpRequest.getMethod());
         Assert.assertEquals(expectedUri, httpRequest.getUri());
         Assert.assertEquals(expectedVersion, httpRequest.getVersion());
         Assert.assertEquals(expectedEndpoint, httpRequest.getEndpoint());
+        Assert.assertTrue(actualMethodReturn);
     }
 
     @Test
@@ -66,10 +81,11 @@ public class HttpRequestTest {
         String expectedData = "data=garfield";
         HttpRequest httpRequest = new HttpRequest();
 
-        httpRequest.parseMessage(request);
+        boolean actualMethodReturn = httpRequest.parseMessage(request);
         String actualData = httpRequest.getData();
 
         Assert.assertEquals(expectedData, actualData);
+        Assert.assertTrue(actualMethodReturn);
     }
 
     @Test
@@ -83,10 +99,11 @@ public class HttpRequestTest {
                                 stream.getBytes(StandardCharsets.UTF_8))));
         HttpRequest httpRequest = new HttpRequest();
 
-        httpRequest.parseMessage(request);
+        boolean actualMethodReturn = httpRequest.parseMessage(request);
         String actualAuth = httpRequest.getAuth();
 
         Assert.assertEquals(expectedAuth, actualAuth);
+        Assert.assertTrue(actualMethodReturn);
     }
 
     @Test
@@ -99,10 +116,11 @@ public class HttpRequestTest {
                                 stream.getBytes(StandardCharsets.UTF_8))));
         HttpRequest httpRequest = new HttpRequest();
 
-        httpRequest.parseMessage(request);
+        boolean actualMethodReturn = httpRequest.parseMessage(request);
         String actualRange = httpRequest.getRange();
 
         Assert.assertEquals(expectedRange, actualRange);
+        Assert.assertTrue(actualMethodReturn);
     }
 
     @Test
@@ -115,10 +133,11 @@ public class HttpRequestTest {
                                 stream.getBytes(StandardCharsets.UTF_8))));
         HttpRequest httpRequest = new HttpRequest();
 
-        httpRequest.parseMessage(request);
+        boolean actualMethodReturn = httpRequest.parseMessage(request);
         String actualEtag = httpRequest.getEtag();
 
         Assert.assertEquals(expectedEtag, actualEtag);
+        Assert.assertTrue(actualMethodReturn);
     }
 
     @Test

--- a/src/test/java/com/richardcheng/javaserver/ServerTest.java
+++ b/src/test/java/com/richardcheng/javaserver/ServerTest.java
@@ -33,6 +33,26 @@ public class ServerTest {
     }
 
     @Test
+    public void run_LoopsThrough_IfAcceptMethodGood_RequestFails_andSkipsResponse() {
+        MockServerSocket mockServerSocket;
+        try {
+            mockServerSocket = new MockServerSocket();
+        } catch (IOException e) {
+            throw new RuntimeException();
+        }
+        MockController mockController = new MockController(null);
+        MockHttpRequestReturnFalse mockHttpRequest = new MockHttpRequestReturnFalse();
+        Server subject = new Server(new ShouldLoop10Times(), mockServerSocket, mockController, mockHttpRequest);
+        int port = 5000;
+
+        subject.run(port);
+
+        Assert.assertTrue(mockServerSocket.setReuseAddressCalled);
+        Assert.assertTrue(mockServerSocket.bindCalled);
+        Assert.assertFalse(mockHttpRequest.requestParsed);
+    }
+
+    @Test
     public void run_serverSocket_bind_throwsException() {
         MockServerSocketBindThrowsException mockServerSocket;
         try {

--- a/src/test/java/com/richardcheng/javaserver/mock/MockHttpRequest.java
+++ b/src/test/java/com/richardcheng/javaserver/mock/MockHttpRequest.java
@@ -7,8 +7,10 @@ import java.io.BufferedReader;
 public class MockHttpRequest extends HttpRequest {
     public boolean requestParsed;
 
-    public void parseMessage(BufferedReader requestMessage) {
+    public boolean parseMessage(BufferedReader requestMessage) {
         requestParsed = true;
+
+        return true;
     }
 
     public String getMethod() {

--- a/src/test/java/com/richardcheng/javaserver/mock/MockHttpRequestReturnFalse.java
+++ b/src/test/java/com/richardcheng/javaserver/mock/MockHttpRequestReturnFalse.java
@@ -1,0 +1,15 @@
+package com.richardcheng.javaserver.mock;
+
+import com.richardcheng.httpIO.HttpRequest;
+
+import java.io.BufferedReader;
+
+public class MockHttpRequestReturnFalse extends HttpRequest {
+    public boolean requestParsed;
+
+    public boolean parseMessage(BufferedReader requestMessage) {
+        requestParsed = false;
+
+        return false;
+    }
+}


### PR DESCRIPTION
…ausing HttpRequest parseMessage to fail because it is not protected against reading an empty line. Add new logic to skip response in Server run if request is not parsed. Add additional tests.
